### PR TITLE
[restapi]Add 3 auto tests for OCF discovery

### DIFF
--- a/meta-iotqa/conf/test/restapiserver.manifest
+++ b/meta-iotqa/conf/test/restapiserver.manifest
@@ -1,4 +1,5 @@
 oeqa.runtime.nodejs.restapiserver.rest_apis
 oeqa.runtime.nodejs.restapiserver.rest_check_local
+oeqa.runtime.nodejs.restapiserver.rest_no_ocf_server_local
 oeqa.runtime.nodejs.restapiserver.rest_one_ocf_server_remote
 oeqa.runtime.nodejs.restapi.server.rest_multi_ocf_servers_remote

--- a/meta-iotqa/lib/oeqa/runtime/nodejs/files/ocfdiscovery/test/test_no_ocf_server.js
+++ b/meta-iotqa/lib/oeqa/runtime/nodejs/files/ocfdiscovery/test/test_no_ocf_server.js
@@ -1,0 +1,130 @@
+const http = require('http'),
+    assert = require('assert'),
+    util = require('util'),
+    spawnSync = require('child_process').spawnSync;
+
+var options_t = {
+    host: '127.0.0.1',
+    port: 8000,
+    path: '',
+    method: 'GET',
+    headers: {
+        'Accept': 'text/json'
+    }
+};
+
+const testCaseTimeout = 20000,
+		waitCommandExecution = 5000;
+
+var options_d = Object.assign({}, options_t);
+options_d.path = '/api/oic/d';
+
+var options_p = Object.assign({}, options_t);
+options_p.path = '/api/oic/p';
+
+var options_res = Object.assign({}, options_t);
+options_res.path = '/api/oic/res';
+
+function operatePort(op, io, protocol, addrMode, port) {
+	var command = util.format('iptables -%s %s -p %s --%s %s -j ACCEPT', 
+								op, io, protocol, addrMode, port)
+	var status = spawnSync('/usr/sbin/iptables', []
+						.concat('-' + op)
+						.concat(io)
+						.concat('-p')
+		  				.concat(protocol)
+		  				.concat('--' + addrMode)
+		  				.concat(port)
+		  				.concat('-j')
+		  				.concat('ACCEPT'), 
+						{
+							stdio: [ process.stdin, process.stdout, process.stderr ],
+							shell: true
+						}).status;
+	if (status !== 0) {
+		console.log('Failed to execute command: %s', command);
+	}
+}
+
+function operateRestApiServer(op) {
+	var command = util.format('systemctl %s iot-rest-api-server', op);
+	var status = spawnSync('/bin/systemctl', []
+							.concat(op)
+							.concat('iot-rest-api-server'),
+							{
+								stdio: [ process.stdin, process.stdout, process.stderr ],
+								shell: true
+							}).status;
+	if (status !== 0) {
+		console.log('Failed to execute command: %s', command);
+	}	
+}
+
+describe('Discover when there is no OCF server running', function() {
+	this.timeout(testCaseTimeout);
+
+	before(function() {
+		operateRestApiServer('start');
+		operatePort('A', 'INPUT', 'tcp', 'dport', 8000);
+		operatePort('A', 'INPUT', 'udp', 'dport', 5683);
+		operatePort('A', 'INPUT', 'udp', 'dport', 5684);
+	});
+
+	describe('platformfound event should not be triggered', function() {	
+		it('no_ocf_platform_found', function(done) {
+			setTimeout(function () {
+			var req = http.request(options_p, function(res) {
+					res.setEncoding('utf8');
+					res.on('data', function (data) {
+						var platforms = JSON.parse(data);
+						assert.ok(Array.isArray(platforms));
+						assert.equal(0, platforms.length);
+						done();
+				});				
+			});
+			req.end();
+			}, waitCommandExecution);
+		});
+	});
+
+	describe('devicefound event should not be triggered', function() {
+		it('no_ocf_device_found', function(done) {
+			setTimeout(function() {
+				var req = http.request(options_d, function(res) {
+						res.setEncoding('utf8');
+						res.on('data', function (data) {
+							var devices = JSON.parse(data);
+							assert.ok(Array.isArray(devices));
+							assert.equal(0, devices.length);
+							done();
+					});			
+				});
+				req.end();				
+			}, waitCommandExecution);
+		});
+	});
+
+	describe('resourcefound event should not be triggered', function() {
+		it('no_ocf_resource_found', function(done) {
+			setTimeout(function() {
+				var req = http.request(options_res, function(res) {
+						res.setEncoding('utf8');
+						res.on('data', function (data) {
+							var resources = JSON.parse(data);
+							assert.ok(Array.isArray(resources));
+							assert.equal(0, resources.length);
+							done();
+					});			
+				});
+				req.end();
+			}, waitCommandExecution);
+		});
+	});
+
+	after(function() {
+		operateRestApiServer('stop');
+		operatePort('D', 'INPUT', 'tcp', 'dport', 8000);
+		operatePort('D', 'INPUT', 'udp', 'dport', 5683);
+		operatePort('D', 'INPUT', 'udp', 'dport', 5684);
+	});
+});

--- a/meta-iotqa/lib/oeqa/runtime/nodejs/restapiserver/copy_necessary_files.py
+++ b/meta-iotqa/lib/oeqa/runtime/nodejs/restapiserver/copy_necessary_files.py
@@ -29,3 +29,18 @@ def copy_rest_api_check_local_js(ip, to_dir = '/home/root'):
 
 	os.chdir(files_dir)
 	os.system('scp -r restapilocal root@{ip}:{to}/SmartHome-Demo'.format(ip = ip, to = to_dir))
+
+def copy_rest_api_ocf_discovery_js(ip, to_dir = '/home/root'):
+	'''
+	Copy local directory ocfdiscovery to to_dir on target devices.
+	'''
+	files_dir = os.path.join(os.path.dirname(os.path.dirname(__file__)), 'files')
+	restapilocal_dir = os.path.join(files_dir, 'ocfdiscovery')
+	mocha_dir = os.path.join(restapilocal_dir, 'node_modules', 'mocha')
+
+	if not os.path.exists(mocha_dir):
+		os.chdir(restapilocal_dir)
+		os.system('npm install mocha')
+
+	os.chdir(files_dir)
+	os.system('scp -r ocfdiscovery root@{ip}:{to}/SmartHome-Demo'.format(ip = ip, to = to_dir))

--- a/meta-iotqa/lib/oeqa/runtime/nodejs/restapiserver/rest_check_local.py
+++ b/meta-iotqa/lib/oeqa/runtime/nodejs/restapiserver/rest_check_local.py
@@ -9,22 +9,22 @@ from oeqa.oetest import oeRuntimeTest
 
 sys.path.append(os.path.dirname(__file__))
 import copy_necessary_files
-import iot_config
+import restapi_case_config
 
 class RestApiCheckLocalTest(oeRuntimeTest):
 
-    iot_target = iot_config.IoTTargetConfiguration()
+    case_config = restapi_case_config.RestApiCaseConfiguration()
 
     @classmethod
     def setUpClass(cls):
         '''
         Copy necessary files to target.
         '''
-        if cls.iot_target.need_copy_files:
+        if cls.case_config.need_copy_files:
             copy_necessary_files.copy_smarthome_demo_ocf_server(cls.tc.target.ip)
             copy_necessary_files.copy_rest_api_check_local_js(cls.tc.target.ip)
 
-        cls.iot_target.prepare_test(cls.tc.target)
+        cls.case_config.prepare_test(cls.tc.target)
 
     def test_restapi_locally(self):
         '''
@@ -32,7 +32,7 @@ class RestApiCheckLocalTest(oeRuntimeTest):
         '''
         test_cmd = 'export NODE_PATH=/usr/lib/node_modules/;'\
                    'cd {js_test_dir};./node_modules/mocha/bin/mocha -R json'.format(
-                        js_test_dir = self.iot_target.js_test_dir)
+                        js_test_dir = self.case_config.js_test_dir)
         (status, output) = self.target.run(test_cmd)
 
         self.parse_test_results(output)
@@ -71,4 +71,4 @@ class RestApiCheckLocalTest(oeRuntimeTest):
         Clean up work.
         '''
         pass
-        # cls.iot_target.clean_up(cls.tc.target)
+        # cls.case_config.clean_up(cls.tc.target)

--- a/meta-iotqa/lib/oeqa/runtime/nodejs/restapiserver/rest_multi_ocf_servers_remote.py
+++ b/meta-iotqa/lib/oeqa/runtime/nodejs/restapiserver/rest_multi_ocf_servers_remote.py
@@ -9,32 +9,32 @@ from oeqa.oetest import oeRuntimeTest
 
 sys.path.append(os.path.dirname(__file__))
 import copy_necessary_files
-import iot_config
+import restapi_case_config
 
 class RestApiMultiOcfServersTest(oeRuntimeTest):
 
-    iot_target = iot_config.IoTTargetConfiguration()
+    case_config = restapi_case_config.RestApiCaseConfiguration()
 
     @classmethod
     def setUpClass(cls):
         '''
         Launch the led.js and gas.js OCF servers on target device.
         '''
-        if cls.iot_target.need_copy_files:
+        if cls.case_config.need_copy_files:
             copy_necessary_files.copy_smarthome_demo_ocf_server(cls.tc.target.ip)
 
-        cls.iot_target.launch_ocf_server(cls.tc.target.ip, 'led.js')
-        cls.iot_target.launch_ocf_server(cls.tc.target.ip, 'gas.js')
-        time.sleep(cls.iot_target.wait_launch_ocf_server)
+        cls.case_config.launch_ocf_server(cls.tc.target.ip, 'led.js')
+        cls.case_config.launch_ocf_server(cls.tc.target.ip, 'gas.js')
+        time.sleep(cls.case_config.wait_launch_ocf_server)
 
-        cls.iot_target.prepare_test(cls.tc.target)
-        cls.iot_target.send_multi_requests(cls.tc.target.ip, 2)
+        cls.case_config.prepare_test(cls.tc.target)
+        cls.case_config.send_multi_requests(cls.tc.target.ip, 2)
 
     def test_multi_ocf_devices_remote(self):
         '''
         Send REST request and find mutiple OCF device.
         '''
-        response = self.iot_target.session.get(self.iot_target.url_oic_d.format(ip = self.target.ip))
+        response = self.case_config.session.get(self.case_config.url_oic_d.format(ip = self.target.ip))
         data = response.content
         devices = json.loads(data.decode('utf8'))
 
@@ -56,7 +56,7 @@ class RestApiMultiOcfServersTest(oeRuntimeTest):
         '''
         Send REST request and find only one OCF platform.
         '''
-        response = self.iot_target.session.get(self.iot_target.url_oic_p.format(ip = self.target.ip))
+        response = self.case_config.session.get(self.case_config.url_oic_p.format(ip = self.target.ip))
         data = response.content
         platforms = json.loads(data.decode('utf8'))
 
@@ -68,7 +68,7 @@ class RestApiMultiOcfServersTest(oeRuntimeTest):
         '''
         Send REST request and find the LED and Gas OCF resource.
         '''
-        response = self.iot_target.session.get(self.iot_target.url_oic_res.format(ip = self.target.ip))
+        response = self.case_config.session.get(self.case_config.url_oic_res.format(ip = self.target.ip))
         data = response.content
         resources = json.loads(data.decode('utf8'))
 
@@ -96,8 +96,8 @@ class RestApiMultiOcfServersTest(oeRuntimeTest):
         '''
         Clean up work.
         '''
-        cls.iot_target.kill_ocf_server(cls.tc.target, 'led.js')  
-        cls.iot_target.kill_ocf_server(cls.tc.target, 'gas.js')
-        time.sleep(cls.iot_target.wait_kill_ocf_server)
+        cls.case_config.kill_ocf_server(cls.tc.target, 'led.js')  
+        cls.case_config.kill_ocf_server(cls.tc.target, 'gas.js')
+        time.sleep(cls.case_config.wait_kill_ocf_server)
 
-        cls.iot_target.clean_up(cls.tc.target)
+        cls.case_config.clean_up(cls.tc.target)

--- a/meta-iotqa/lib/oeqa/runtime/nodejs/restapiserver/rest_one_ocf_server_remote.py
+++ b/meta-iotqa/lib/oeqa/runtime/nodejs/restapiserver/rest_one_ocf_server_remote.py
@@ -9,31 +9,31 @@ from oeqa.oetest import oeRuntimeTest
 
 sys.path.append(os.path.dirname(__file__))
 import copy_necessary_files
-import iot_config
+import restapi_case_config
 
 class RestApiOneOcfServerTest(oeRuntimeTest):
     
-    iot_target = iot_config.IoTTargetConfiguration()
+    case_config = restapi_case_config.RestApiCaseConfiguration()
 
     @classmethod
     def setUpClass(cls):
         '''
         Launch the OCF server on target device.
         '''
-        if cls.iot_target.need_copy_files:
+        if cls.case_config.need_copy_files:
             copy_necessary_files.copy_smarthome_demo_ocf_server(cls.tc.target.ip)
 
-        cls.iot_target.launch_ocf_server(cls.tc.target.ip, 'led.js')
-        time.sleep(cls.iot_target.wait_launch_ocf_server)
+        cls.case_config.launch_ocf_server(cls.tc.target.ip, 'led.js')
+        time.sleep(cls.case_config.wait_launch_ocf_server)
 
-        cls.iot_target.prepare_test(cls.tc.target)
-        cls.iot_target.send_multi_requests(cls.tc.target.ip, 2)
+        cls.case_config.prepare_test(cls.tc.target)
+        cls.case_config.send_multi_requests(cls.tc.target.ip, 2)
 
     def test_unique_ocf_device_remote(self):
         '''
         Send REST request again and find only one OCF device.
         '''
-        response = self.iot_target.session.get(self.iot_target.url_oic_d.format(ip = self.target.ip))
+        response = self.case_config.session.get(self.case_config.url_oic_d.format(ip = self.target.ip))
         data = response.content
         devices = json.loads(data.decode('utf8'))
 
@@ -44,7 +44,7 @@ class RestApiOneOcfServerTest(oeRuntimeTest):
         '''
         Send a REST request again and find only one OCF platform.
         '''
-        response = self.iot_target.session.get(self.iot_target.url_oic_p.format(ip = self.target.ip))
+        response = self.case_config.session.get(self.case_config.url_oic_p.format(ip = self.target.ip))
         data = response.content
         platforms = json.loads(data.decode('utf8'))
 
@@ -55,7 +55,7 @@ class RestApiOneOcfServerTest(oeRuntimeTest):
         '''
         Send a REST request again and find only one OCF resource.
         '''
-        response = self.iot_target.session.get(self.iot_target.url_oic_res.format(ip = self.target.ip))
+        response = self.case_config.session.get(self.case_config.url_oic_res.format(ip = self.target.ip))
         data = response.content
         resources = json.loads(data.decode('utf8'))
 
@@ -75,7 +75,7 @@ class RestApiOneOcfServerTest(oeRuntimeTest):
         '''
         Clean up work.
         '''
-        cls.iot_target.kill_ocf_server(cls.tc.target, 'led.js')
-        time.sleep(cls.iot_target.wait_kill_ocf_server)
+        cls.case_config.kill_ocf_server(cls.tc.target, 'led.js')
+        time.sleep(cls.case_config.wait_kill_ocf_server)
 
-        cls.iot_target.clean_up(cls.tc.target)
+        cls.case_config.clean_up(cls.tc.target)

--- a/meta-iotqa/lib/oeqa/runtime/nodejs/restapiserver/restapi_case_config.py
+++ b/meta-iotqa/lib/oeqa/runtime/nodejs/restapiserver/restapi_case_config.py
@@ -3,9 +3,9 @@
 import os
 import requests
 
-class IoTTargetConfiguration:
+class RestApiCaseConfiguration:
 	'''
-	IoT Target configuration
+	Rest API test cases configuration
 	'''
 
 	def __init__(self):
@@ -14,6 +14,7 @@ class IoTTargetConfiguration:
 		self.sh_demo_dir = os.path.join(self.home_dir, 'SmartHome-Demo')
 		self.js_test_dir = os.path.join(self.sh_demo_dir, self.restapilocal)
 		self.ocf_dir = os.path.join(self.sh_demo_dir, 'ocf-servers', 'js-servers')
+		self.ocf_js_test_dir = os.path.join(self.sh_demo_dir, 'ocfdiscovery')
 
 		self.cleanup = True
 		self.need_copy_files = True


### PR DESCRIPTION
* Add 3 test cases for OCF discovery when there is no OCF server running on the IoT device.
* Rename the configuration for test cases.

Test case impact: new:3 update: 14
Test results: Pass:11 Failed:6
Releated issues: [issue#126](https://github.com/otcshare/iotivity-node/issues/126) [issue#127](https://github.com/otcshare/iotivity-node/issues/127)

Signed-off-by: Qiu Zhong <zhongx.qiu@intel.com>