### PR TITLE
Add the cordova plugin ocf apps automatic cases.

### DIFF
--- a/meta-iotqa/conf/test/ocfclientapp.manifest
+++ b/meta-iotqa/conf/test/ocfclientapp.manifest
@@ -1,0 +1,16 @@
+oeqa.runtime.nodejs.ocfdemoapp.app
+oeqa.runtime.nodejs.ocfdemoapp.ambient_light
+oeqa.runtime.nodejs.ocfdemoapp.button
+oeqa.runtime.nodejs.ocfdemoapp.button_toggle
+oeqa.runtime.nodejs.ocfdemoapp.buzzer
+oeqa.runtime.nodejs.ocfdemoapp.env
+oeqa.runtime.nodejs.ocfdemoapp.fan
+oeqa.runtime.nodejs.ocfdemoapp.gas
+oeqa.runtime.nodejs.ocfdemoapp.led
+oeqa.runtime.nodejs.ocfdemoapp.motion
+oeqa.runtime.nodejs.ocfdemoapp.power
+oeqa.runtime.nodejs.ocfdemoapp.rgb_led
+oeqa.runtime.nodejs.ocfdemoapp.solar
+oeqa.runtime.nodejs.ocfdemoapp.switch
+oeqa.runtime.nodejs.ocfdemoapp.temperature
+oeqa.runtime.nodejs.smarthomectlapp.app

--- a/meta-iotqa/lib/oeqa/runtime/nodejs/ocfdemoapp/ambient_light.py
+++ b/meta-iotqa/lib/oeqa/runtime/nodejs/ocfdemoapp/ambient_light.py
@@ -1,0 +1,96 @@
+#!/usr/bin/env python3
+
+import os
+import sys
+import time
+import subprocess
+
+from uiautomator import device as d
+from uiautomator import JsonRPCError
+
+from oeqa.oetest import oeRuntimeTest
+
+sys.path.append(os.path.dirname(__file__))
+from appmgr import AppMgr
+import data_settings
+
+
+class CordovaPluginOCFDemoAppAmbientLightTest(oeRuntimeTest):
+    '''Automatize the Cordova plugin OCF demo app tests like
+    checking if the resources are found, and resource information is readonly.'''
+
+    pkg_id = 'com.example.CordovaPluginOcfDemo'
+    ambient_light_item = None
+    device_found = False
+    resource_found = False
+
+    details_btn = None
+    id_item = None
+    illuminance_value_item = None
+    illuminance_value = 0.0
+
+    appmgr = AppMgr()
+
+    @classmethod
+    def setUpClass(cls):
+        '''
+        Launch the app and find the OCF resources.
+        '''
+        cls.appmgr.kill_app(cls.pkg_id)
+        cls.appmgr.launch_app(cls.pkg_id)
+        time.sleep(data_settings.app_launch_and_wait)
+
+
+    def init_illuminance_sensor(self):
+        '''
+        Go to the detailed page of the OCF resource.
+        '''
+        self.ambient_light_item = d(className='android.view.View', descriptionContains='Path: /a/illuminance')
+        self.ambient_light_item.click()
+        time.sleep(1)
+
+        self.details_btn = d(className='android.widget.Button')
+        self.id_item = d(className='android.view.View', descriptionStartsWith='id')
+        self.illuminance_value_item = d(className='android.view.View', descriptionStartsWith='illuminance')
+        self.illuminance_value = float(self.illuminance_value_item.description.split(':')[-1].strip())
+
+
+    def test_ambient_light_resource_found(self):
+        '''Check if the ambient light resource can be found.'''
+        self.appmgr.go_to_resources_for_ocfdemo()
+        time.sleep(data_settings.app_found_res_and_wait)
+
+        self.resource_found = d.exists(className='android.view.View', descriptionContains='/a/illuminance')
+        self.assertTrue(self.resource_found, 'The ambient light resource is not found.')
+
+
+    def test_ambient_light_resource_properties_readonly(self):
+        '''Check if the properties of the ambient light resource are readonly.'''
+        self.init_illuminance_sensor()
+
+        self.assertEqual(len(self.details_btn), 1, 'The properties of illuminance is not readonly.')
+        self.assertEqual(self.id_item.description.split(':')[-1].strip(), 'illuminance', 
+                        'Device of illuminance resource not found.')
+        self.assertTrue(self.illuminance_value > 5.0, 'Illuminace value is invalid.')
+
+
+    def test_ambient_light_z_device_found(self):
+        '''Check if the OCF device can be found.'''
+        self.appmgr.go_to_devices_for_ocfdemo()
+        time.sleep(data_settings.app_found_dev_and_wait)
+
+        self.device_found = d.exists(descriptionContains='UUID')
+        self.device_found = self.device_found and d.exists(descriptionContains='URL')
+        self.device_found = self.device_found and d.exists(descriptionContains='Name')
+        self.device_found = self.device_found and d.exists(descriptionContains='Data models')
+        self.device_found = self.device_found and d.exists(descriptionContains='Core spec version')
+        self.device_found = self.device_found and d.exists(descriptionContains='Role')
+
+        self.assertTrue(self.device_found, 'OCF device is not found.')
+
+
+    @classmethod
+    def tearDownClass(cls):
+        '''Terminate the app.'''
+        cls.appmgr.kill_app(cls.pkg_id)
+

--- a/meta-iotqa/lib/oeqa/runtime/nodejs/ocfdemoapp/app.py
+++ b/meta-iotqa/lib/oeqa/runtime/nodejs/ocfdemoapp/app.py
@@ -1,0 +1,112 @@
+#!/usr/bin/env python3
+
+import os
+import sys
+import time
+import subprocess
+
+from uiautomator import device as d
+sys.path.append(os.path.dirname(__file__))
+from appmgr import AppMgr
+
+from oeqa.oetest import oeRuntimeTest
+
+
+class OCFDemoAppBuildAndLaunchTest(oeRuntimeTest):
+    '''
+    Build/Install/Launch the CordovaPluginOCFDemo app.
+    '''
+    workspace_dir = os.path.dirname(__file__)
+    cordova_pluin_ocf_demo_url = 'https://github.com/siovene/cordova-plugin-ocf-demo.git'
+    pkg_id = 'com.example.CordovaPluginOcfDemo'
+    repo_dir = 'cordova-plugin-ocf-demo'
+    prj_dir = os.path.join(workspace_dir, repo_dir)
+    apk_path = 'platforms/android/build/outputs/apk/android-debug.apk'
+
+    clean_up = False
+    uninstall_app = False
+    appmgr = AppMgr()
+
+    def setUp(self):
+        '''
+        Check if the grunt-cli and bower are installed. Install them globally if not.
+        '''
+        self.appmgr.uninstall_app(self.pkg_id)
+
+        cli_cmd = ['grunt', 'bower']
+        for cmd in cli_cmd:
+            detect_cmd = ['which'] + [cmd]
+            proc = subprocess.Popen(detect_cmd, stdout = subprocess.PIPE, stderr=subprocess.STDOUT)
+            proc.wait()
+
+            if proc.returncode != 0:
+                if cmd == 'grunt':
+                    cli = 'grunt-cli'
+                else:
+                    cli = cmd
+                print('{} not installed, install it...'.format(cli))
+                proc_cli = subprocess.Popen(['sudo', '-E', 'npm', cli, '-g'])
+                proc_cli.communicate()
+
+            else:
+                print('{} has been installed'.format(cmd))
+
+        detect_dev = ['adb', 'devices']
+        proc_adb = subprocess.Popen(detect_dev, stdout = subprocess.PIPE, stderr=subprocess.STDOUT)
+        proc_adb.wait()
+
+        adb_info = proc_adb.stdout.read().decode('utf8').strip()
+        if proc_adb.returncode != 0 or not adb_info.endswith('device'):
+            print('Please check if the android device is connected to the host.')
+
+
+    def test_ocfdemo_build_install_launch(self):
+        '''
+        Check if there're any errors during the following steps:
+        1. git clone the cordova-plugin-ocf-demo
+        2. build the app
+        3. install and launch it
+        '''
+        clone_cmd = ['git', 'clone', '--depth', '1', '--single-branch', '--branch', 'master', 
+                    self.cordova_pluin_ocf_demo_url]
+        clone_proc = subprocess.Popen(clone_cmd, cwd = self.workspace_dir)
+        clone_proc.wait()
+
+        self.assertEqual(clone_proc.returncode, 0, 'clone the cordova_pluin_ocf_demo failed.')
+
+        build_cmds = [['npm', 'install'], ['bower', 'install'], 
+                    ['grunt', 'platform:add:android'], ['grunt', 'build']]
+        for build_cmd in build_cmds:
+            build_proc = subprocess.Popen(build_cmd, cwd = self.prj_dir)
+            build_proc.wait()
+
+            self.assertEqual(build_proc.returncode, 0, 'Failed to build when running [{0}]'.format(build_cmd))
+
+        self.assertTrue(os.path.exists(self.prj_dir), 'cordova-plugin-ocf-demo apk is not found!')
+        install_cmd = ['adb', 'install',  self.apk_path]
+        install_proc = subprocess.Popen(install_cmd, cwd = self.prj_dir)
+        install_proc.wait()
+
+        self.assertEqual(install_proc.returncode, 0, 'Failed to install OCF Demo apk')
+
+        self.appmgr.launch_app(self.pkg_id)
+        time.sleep(5)
+
+        btn = d(className='android.widget.Button', index=0)
+        btn.click()
+
+        title_found = d.exists(className='android.view.View', descriptionContains='OCF Demo')
+        self.assertTrue(title_found, 'Launching the app OK?')
+
+
+    def tearDown(self):
+        '''
+        Remove the cordova-plugin-ocf-demo project as it not needed any more.
+        '''
+        if self.clean_up:
+            os.chdir(self.workspace_dir)
+            os.system('rm -fr {}'.format(self.repo_dir))
+
+        if self.uninstall_app:
+            self.appmgr.uninstall_app(self.pkg_id)
+        

--- a/meta-iotqa/lib/oeqa/runtime/nodejs/ocfdemoapp/appmgr.py
+++ b/meta-iotqa/lib/oeqa/runtime/nodejs/ocfdemoapp/appmgr.py
@@ -1,0 +1,108 @@
+#!/usr/bin/env python3
+
+import time
+import subprocess
+from uiautomator import device as d
+
+
+class AppMgr:
+    in_main_panel = True
+
+
+    def install_app(self, apk_path):
+        '''
+        Install an apk file specified by apk_path.
+        '''
+        install_cmd = 'adb install {}'.format(apk_path).split()
+        p = subprocess.Popen(install_cmd, stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
+        p.communicate()
+
+    def uninstall_app(self, package_name):
+        '''
+        Unstall an apk file specified by apk_path.
+        '''
+        uninstall_cmd = 'adb uninstall {}'.format(package_name).split()
+        p = subprocess.Popen(uninstall_cmd, stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
+        p.communicate()
+
+
+
+    def launch_app(self, package_name):
+        '''
+        Launch an app by the package id.
+        '''
+        launch_cmd = 'adb shell am start -n {pkg_id}/.MainActivity'.format(pkg_id=package_name).split()
+        p = subprocess.Popen(launch_cmd, stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
+        p.communicate()
+
+
+    def kill_app(self, package_name):
+        '''Terminate an app.'''
+        exit_cmd = 'adb shell am force-stop {pkg_id}'.format(pkg_id=package_name).split()
+        p = subprocess.Popen(exit_cmd, stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
+        p.communicate()
+
+
+    # def app_goes_to_bg(self):
+    #     d.screen.back()
+
+    def go_to_panel_for_ocfdemo(self, title):
+        '''
+        Switch to the the panel specified by the title.
+        '''
+        # print('found:' + str(d.exists(className='android.widget.Button', index=0)))
+        side_bar_btn = d(className='android.widget.Button', index=0)
+        side_bar_btn.click()
+
+        res_btn = d(className='android.view.View', description=title)
+        res_btn.click()
+
+
+    def go_back(self):
+        '''
+        Go back to the main panel from the resource detail panel.
+        '''
+        # if not self.in_main_panel:
+        back_btn = d(className='android.widget.Button', index=0)
+        back_btn.click()
+
+
+    def go_to_resources_for_ocfdemo(self):
+        '''
+        Switch to the resource pandel
+        '''
+        self.go_to_panel_for_ocfdemo('Resources')
+
+
+    def go_to_devices_for_ocfdemo(self):
+        # self.go_back()
+        self.go_to_panel_for_ocfdemo('Devices')
+
+
+    def open_continuous_discovery(self, package_name):
+        '''
+        Open the Continuous discovery switch and enable it.
+        Return if it's set to True.
+        '''
+        self.launch_app(package_name)
+        time.sleep(2)
+
+        side_bar_btn = d(className='android.widget.Button', index=0)
+        side_bar_btn.click()
+        time.sleep(2)
+
+        settings_btn = d(className='android.view.View', description='Settings')
+        settings_btn.click()
+        time.sleep(2)
+
+        switch_btn = d(className='android.view.View', index=6)
+        switch_btn.click()
+
+
+
+# if __name__ == '__main__':
+#     appmgr = AppMgr()
+#     appmgr.open_continuous_discovery('com.example.CordovaPluginOcfDemo')
+
+#     time.sleep(2)
+

--- a/meta-iotqa/lib/oeqa/runtime/nodejs/ocfdemoapp/button.py
+++ b/meta-iotqa/lib/oeqa/runtime/nodejs/ocfdemoapp/button.py
@@ -1,0 +1,95 @@
+#!/usr/bin/env python3
+
+import os
+import sys
+import time
+import subprocess
+
+from uiautomator import device as d
+
+from oeqa.oetest import oeRuntimeTest
+
+sys.path.append(os.path.dirname(__file__))
+from appmgr import AppMgr
+import data_settings
+
+
+class CordovaPluginOCFDemoAppButtonTest(oeRuntimeTest):
+    '''Automatize the Cordova plugin OCF demo app tests like
+    checking if the resources are found, and resource information is readonly.
+    '''
+    pkg_id = 'com.example.CordovaPluginOcfDemo'
+    button_item = None
+    device_found = False
+    resource_found = False
+
+    details_btn = None
+    id_item = None
+    button_value_item = None
+    button_value = None
+
+    appmgr = AppMgr()
+
+    @classmethod
+    def setUpClass(cls):
+        '''
+        Launch the app and find the OCF resources.
+        '''
+        cls.appmgr.kill_app(cls.pkg_id)
+        cls.appmgr.launch_app(cls.pkg_id)
+        time.sleep(data_settings.app_launch_and_wait)
+
+
+    def init_button_sensor(self):
+        '''
+        Go to the detailed page of the OCF resource.
+        '''
+        self.button_item = d(className='android.view.View', descriptionContains='Path: /a/button')
+        self.button_item.click()
+        time.sleep(1)
+
+        self.details_btn = d(className='android.widget.Button')
+        self.id_item = d(className='android.view.View', descriptionStartsWith='id')
+        self.button_value_item = d(className='android.view.View', descriptionStartsWith='value')
+        self.button_value = self.button_value_item.description.split(':')[-1].strip()
+
+
+    def test_button_resource_found(self):
+        '''Check if the button resource can be found.'''
+        self.appmgr.go_to_resources_for_ocfdemo()
+        time.sleep(data_settings.app_found_res_and_wait)
+        
+        self.resource_found = d.exists(className='android.view.View', descriptionContains='/a/button')
+        self.assertTrue(self.resource_found, 'Button resource is not found.')
+
+
+    def test_button_resource_properties_readonly(self):
+        '''Check if the properties of button resource are readonly.'''
+        self.init_button_sensor()
+
+        self.assertEqual(len(self.details_btn), 1, 'The properties of button are not readonly.')
+        self.assertEqual(self.id_item.description.split(':')[-1].strip(), 'button', 
+                        'Id of button resource not found.')
+        self.assertEqual(self.button_value, 'false', 'Initial button value is not false!')
+
+
+    def test_button_z_device_found(self):
+        '''Check if the OCF device can be found.'''
+        self.appmgr.go_to_devices_for_ocfdemo()
+        time.sleep(data_settings.app_found_dev_and_wait)
+
+        self.device_found = d.exists(descriptionContains='UUID')
+        self.device_found = self.device_found and d.exists(descriptionContains='URL')
+        self.device_found = self.device_found and d.exists(descriptionContains='Name')
+        self.device_found = self.device_found and d.exists(descriptionContains='Data models')
+        self.device_found = self.device_found and d.exists(descriptionContains='Core spec version')
+        self.device_found = self.device_found and d.exists(descriptionContains='Role')
+
+        self.assertTrue(self.device_found, 'OCF device is not found.')
+
+
+    @classmethod
+    def tearDownClass(cls):
+        '''Terminate the app.'''
+        cls.appmgr.kill_app(cls.pkg_id)
+

--- a/meta-iotqa/lib/oeqa/runtime/nodejs/ocfdemoapp/button_toggle.py
+++ b/meta-iotqa/lib/oeqa/runtime/nodejs/ocfdemoapp/button_toggle.py
@@ -1,0 +1,96 @@
+#!/usr/bin/env python3
+
+import os
+import sys
+import time
+import subprocess
+
+from uiautomator import device as d
+from uiautomator import JsonRPCError
+
+from oeqa.oetest import oeRuntimeTest
+
+sys.path.append(os.path.dirname(__file__))
+from appmgr import AppMgr
+import data_settings
+
+
+class CordovaPluginOCFDemoAppButtonToggleTest(oeRuntimeTest):
+    '''Automatize the Cordova plugin OCF demo app tests like
+    checking if the resources are found, and resource information is readonly.
+    '''
+    pkg_id = 'com.example.CordovaPluginOcfDemo'
+    button_toggle_item = None
+    device_found = False
+    resource_found = False
+
+    details_btn = None
+    id_item = None
+    button_toggle_value_item = None
+    button_toggle_value = None
+
+    appmgr = AppMgr()
+
+    @classmethod
+    def setUpClass(cls):
+        '''
+        Launch the app and find the OCF resources.
+        '''
+        cls.appmgr.kill_app(cls.pkg_id)
+        cls.appmgr.launch_app(cls.pkg_id)
+        time.sleep(data_settings.app_launch_and_wait)
+
+
+    def init_button_toggle_sensor(self):
+        '''
+        Go to the detailed page of the OCF resource.
+        '''
+        self.button_toggle_item = d(className='android.view.View', descriptionContains='Path: /a/button')
+        self.button_toggle_item.click()
+        time.sleep(1)
+
+        self.details_btn = d(className='android.widget.Button')
+        self.id_item = d(className='android.view.View', descriptionStartsWith='id')
+        self.button_toggle_value_item = d(className='android.view.View', descriptionStartsWith='value')
+        self.button_toggle_value = self.button_toggle_value_item.description.split(':')[-1].strip()
+
+
+    def test_button_toggle_resource_found(self):
+        '''Check if the button toggle resources can be found.'''
+        self.appmgr.go_to_resources_for_ocfdemo()
+        time.sleep(data_settings.app_found_res_and_wait)
+
+        self.resource_found = d.exists(className='android.view.View', descriptionContains='/a/button')
+        self.assertTrue(self.resource_found, 'The button toggle resource is not found.')
+
+
+    def test_button_toggle_resource_properties_readonly(self):
+        '''Check if the properties of the button toggle resources are readonly.'''
+        self.init_button_toggle_sensor()
+
+        self.assertEqual(len(self.details_btn), 1, 'The properties of button toggle are not readonly.')
+        self.assertEqual(self.id_item.description.split(':')[-1].strip(), 'button', 
+                        'Id of button resource not found.')
+        self.assertEqual(self.button_toggle_value, 'false', 'Initial button toggle value is not false!')
+
+
+    def test_button_toggle_z_device_found(self):
+        '''Check if the OCF device can be found.'''
+        self.appmgr.go_to_devices_for_ocfdemo()
+        time.sleep(data_settings.app_found_dev_and_wait)
+
+        self.device_found = d.exists(descriptionContains='UUID')
+        self.device_found = self.device_found and d.exists(descriptionContains='URL')
+        self.device_found = self.device_found and d.exists(descriptionContains='Name')
+        self.device_found = self.device_found and d.exists(descriptionContains='Data models')
+        self.device_found = self.device_found and d.exists(descriptionContains='Core spec version')
+        self.device_found = self.device_found and d.exists(descriptionContains='Role')
+
+        self.assertTrue(self.device_found, 'OCF device is not found.')
+
+
+    @classmethod
+    def tearDownClass(cls):
+        '''Terminate the app.'''
+        cls.appmgr.kill_app(cls.pkg_id)
+

--- a/meta-iotqa/lib/oeqa/runtime/nodejs/ocfdemoapp/buzzer.py
+++ b/meta-iotqa/lib/oeqa/runtime/nodejs/ocfdemoapp/buzzer.py
@@ -1,0 +1,95 @@
+#!/usr/bin/env python3
+
+import os
+import sys
+import time
+import subprocess
+
+from uiautomator import device as d
+
+from oeqa.oetest import oeRuntimeTest
+
+sys.path.append(os.path.dirname(__file__))
+from appmgr import AppMgr
+import data_settings
+
+
+class CordovaPluginOCFDemoAppBuzzerTest(oeRuntimeTest):
+    '''Automatize the Cordova plugin OCF demo app tests like
+    checking if the resources are found, and resource information is readonly.
+    '''
+    pkg_id = 'com.example.CordovaPluginOcfDemo'
+    buzzer_item = None
+    device_found = False
+    resource_found = False
+
+    details_btn = None
+    id_item = None
+    buzzer_value_item = None
+    buzzer_value = None
+
+    appmgr = AppMgr()
+
+    @classmethod
+    def setUpClass(cls):
+        '''
+        Launch the app and find the OCF resources.
+        '''
+        cls.appmgr.kill_app(cls.pkg_id)
+        cls.appmgr.launch_app(cls.pkg_id)
+        time.sleep(data_settings.app_launch_and_wait)
+
+
+    def init_buzzer_sensor(self):
+        '''
+        Go to the detailed page of the OCF resource.
+        '''
+        self.buzzer_item = d(className='android.view.View', descriptionContains='Path: /a/buzzer')
+        self.buzzer_item.click()
+        time.sleep(1)
+
+        self.details_btn = d(className='android.widget.Button')
+        self.id_item = d(className='android.view.View', descriptionStartsWith='id')
+        self.buzzer_value_item = d(className='android.view.View', descriptionStartsWith='value')
+        self.buzzer_value = self.buzzer_value_item.description.split(':')[-1].strip()
+
+
+    def test_buzzer_resource_found(self):
+        '''Check if the buzzer resource can be found.'''
+        self.appmgr.go_to_resources_for_ocfdemo()
+        time.sleep(data_settings.app_found_res_and_wait)
+
+        self.resource_found = d.exists(className='android.view.View', descriptionContains='/a/buzzer')
+        self.assertTrue(self.resource_found, 'The buzzer resource is not found.')
+
+
+    def test_buzzer_resource_properties_readonly(self):
+        '''Check if the properties of buzzer resources are readonly.'''
+        self.init_buzzer_sensor()
+
+        self.assertEqual(len(self.details_btn), 1, 'The properties of buzzer is not readonly.')
+        self.assertEqual(self.id_item.description.split(':')[-1].strip(), 'buzzer', 
+                        'Id of buzzer resource not found.')
+        self.assertEqual(self.buzzer_value, 'false', 'Initial buzzer value is not false!')
+
+
+    def test_buzzer_z_device_found(self):
+        ''''Check if the OCF device can be found.'''
+        self.appmgr.go_to_devices_for_ocfdemo()
+        time.sleep(data_settings.app_found_dev_and_wait)
+
+        self.device_found = d.exists(descriptionContains='UUID')
+        self.device_found = self.device_found and d.exists(descriptionContains='URL')
+        self.device_found = self.device_found and d.exists(descriptionContains='Name')
+        self.device_found = self.device_found and d.exists(descriptionContains='Data models')
+        self.device_found = self.device_found and d.exists(descriptionContains='Core spec version')
+        self.device_found = self.device_found and d.exists(descriptionContains='Role')
+
+        self.assertTrue(self.device_found, 'OCF device is not found.')
+
+
+    @classmethod
+    def tearDownClass(cls):
+        '''Terminate the app.'''
+        cls.appmgr.kill_app(cls.pkg_id)
+

--- a/meta-iotqa/lib/oeqa/runtime/nodejs/ocfdemoapp/data_settings.py
+++ b/meta-iotqa/lib/oeqa/runtime/nodejs/ocfdemoapp/data_settings.py
@@ -1,0 +1,4 @@
+app_launch_and_wait = 10
+app_found_res_and_wait = 20
+app_found_dev_and_wait = 20
+

--- a/meta-iotqa/lib/oeqa/runtime/nodejs/ocfdemoapp/env.py
+++ b/meta-iotqa/lib/oeqa/runtime/nodejs/ocfdemoapp/env.py
@@ -1,0 +1,114 @@
+#!/usr/bin/env python3
+
+import os
+import sys
+import time
+import subprocess
+
+from uiautomator import device as d
+
+from oeqa.oetest import oeRuntimeTest
+
+sys.path.append(os.path.dirname(__file__))
+from appmgr import AppMgr
+import data_settings
+
+
+class CordovaPluginOCFDemoAppEnvTest(oeRuntimeTest):
+    '''Automatize the Cordova plugin OCF demo app tests like
+    checking if the resources are found, and resource information is readonly.
+    '''
+    pkg_id = 'com.example.CordovaPluginOcfDemo'
+    env_item = None
+    device_found = False
+    resource_found = False
+
+    details_btn = None
+    humidity_item = None
+    humidity_value = 0.0
+    id_item = None
+    pressure_item = None
+    pressure_value = 0.0
+    temperature_item = None
+    temperature_value = 0.0
+    unindex_item = None
+    uvindex_value = None
+
+    appmgr = AppMgr()
+
+    @classmethod
+    def setUpClass(cls):
+        '''
+        Launch the app and find the OCF resources.
+        '''
+        cls.appmgr.kill_app(cls.pkg_id)
+        cls.appmgr.launch_app(cls.pkg_id)
+        time.sleep(data_settings.app_launch_and_wait)
+
+
+    def init_env_sensor(self):
+        '''
+        Go to the detaienv page of the OCF resource.
+        '''
+        self.env_item = d(className='android.view.View', descriptionContains='Path: /a/env')
+        self.env_item.click()
+        time.sleep(1)
+
+        self.details_btn = d(className='android.widget.Button')
+        self.humidity_item = d(className='android.view.View', descriptionStartsWith='humidity')
+        self.humidity_value = float(self.humidity_item.description.split(':')[-1].strip())
+
+        self.id_item = d(className='android.view.View', descriptionStartsWith='id')
+
+        self.pressure_item = d(className='android.view.View', descriptionStartsWith='pressure')
+        self.pressure_value = float(self.pressure_item.description.split(':')[-1].strip())
+
+        self.temperature_item = d(className='android.view.View', descriptionStartsWith='temperature')
+        self.temperature_value = float(self.temperature_item.description.split(':')[-1].strip())
+
+        self.uvindex_item = d(className='android.view.View', descriptionStartsWith='uvIndex')
+        self.uvindex_value = int(self.uvindex_item.description.split(':')[-1].strip())
+
+
+    def test_env_resource_found(self):
+        '''Check if the env resources can be found.'''
+        self.appmgr.go_to_resources_for_ocfdemo()
+        time.sleep(data_settings.app_found_res_and_wait)
+
+        self.resource_found = d.exists(className='android.view.View', descriptionContains='/a/env')
+        self.assertTrue(self.resource_found, 'The environment resource is not found.')
+
+
+    def test_env_resource_has_properties(self):
+        '''Check if the env resource has properties like id and value.'''
+        self.init_env_sensor()
+
+        self.assertEqual(len(self.details_btn), 1)
+        self.assertTrue(self.humidity_value >= 0.0, 'Invalid humidity number.')
+        self.assertEqual(self.id_item.description.split(':')[-1].strip(), 'environmentalSensor',
+                         'Id of env resource not found.', )
+        self.assertTrue(self.pressure_value >= 1000.0, 'Pressure seems not sensible!')
+        self.assertTrue(self.temperature_value >= 15.0, 'Temperature seems not sensible!')
+        self.assertTrue(self.uvindex_value >= 0, 'env value is empty!')
+
+
+    def test_env_z_device_found(self):
+        ''''Check if the OCF device can be found.'''
+        self.appmgr.go_to_devices_for_ocfdemo()
+        time.sleep(data_settings.app_found_dev_and_wait)
+
+        self.device_found = d.exists(descriptionContains='UUID')
+        self.device_found = self.device_found and d.exists(descriptionContains='URL')
+        self.device_found = self.device_found and d.exists(descriptionContains='Name')
+        self.device_found = self.device_found and d.exists(descriptionContains='Data models')
+        self.device_found = self.device_found and d.exists(descriptionContains='Core spec version')
+        self.device_found = self.device_found and d.exists(descriptionContains='Role')
+
+        self.assertTrue(self.device_found, 'OCF device is not found.')
+
+
+    @classmethod
+    def tearDownClass(cls):
+        '''Terminate the app.'''
+        cls.appmgr.kill_app(cls.pkg_id)
+

--- a/meta-iotqa/lib/oeqa/runtime/nodejs/ocfdemoapp/fan.py
+++ b/meta-iotqa/lib/oeqa/runtime/nodejs/ocfdemoapp/fan.py
@@ -1,0 +1,96 @@
+#!/usr/bin/env python3
+
+import os
+import sys
+import time
+import subprocess
+
+from uiautomator import device as d
+
+from oeqa.oetest import oeRuntimeTest
+
+sys.path.append(os.path.dirname(__file__))
+from appmgr import AppMgr
+import data_settings
+
+
+class CordovaPluginOCFDemoAppfanTest(oeRuntimeTest):
+    '''Automatize the Cordova plugin OCF demo app tests like
+    checking if the resources are found, and resource information is readonly.
+    '''
+    pkg_id = 'com.example.CordovaPluginOcfDemo'
+    fan_item = None
+    device_found = False
+    resource_found = False
+
+    details_btn = None
+    id_item = None
+    fan_value_item = None
+    fan_value = None
+
+    appmgr = AppMgr()
+
+    @classmethod
+    def setUpClass(cls):
+        '''
+        Launch the app and find the OCF resources.
+        '''
+        cls.appmgr.kill_app(cls.pkg_id)
+        cls.appmgr.launch_app(cls.pkg_id)
+        time.sleep(data_settings.app_launch_and_wait)
+
+
+    @classmethod
+    def init_fan_sensor(self):
+        '''
+        Go to the detailed page of the OCF resource.
+        '''
+        self.fan_item = d(className='android.view.View', descriptionContains='Path: /a/fan')
+        self.fan_item.click()
+        time.sleep(1)
+
+        self.details_btn = d(className='android.widget.Button')
+        self.id_item = d(className='android.view.View', descriptionStartsWith='id')
+        self.fan_value_item = d(className='android.view.View', index=14).child(className='android.view.View', index=1)
+        self.fan_value = self.fan_value_item.description.split(':')[-1].strip()
+
+
+    def test_fan_resource_found(self):
+        '''Check if the fan resource can be found'''
+        self.appmgr.go_to_resources_for_ocfdemo()
+        time.sleep(data_settings.app_found_res_and_wait)
+
+        self.resource_found = d.exists(className='android.view.View', descriptionContains='/a/fan')
+        self.assertTrue(self.resource_found, 'The fan resource is not found.')
+
+
+    def test_fan_resource_has_properties(self):
+        '''Check if the fan resource has properties like id and value'''
+        self.init_fan_sensor()
+
+        self.assertEqual(len(self.details_btn), 2)
+        self.assertEqual(self.id_item.description.split(':')[-1].strip(), 'boxFan',
+                         'Id of fan resource not found.')
+        self.assertEqual(self.fan_value, 'false', 'Initial fan value is not false!')
+
+
+    def test_fan_z_device_found(self):
+        ''''Check if the OCF device can be found.'''
+        self.appmgr.go_to_devices_for_ocfdemo()
+        time.sleep(data_settings.app_found_dev_and_wait)
+
+        self.device_found = d.exists(descriptionContains='UUID')
+        self.device_found = self.device_found and d.exists(descriptionContains='URL')
+        self.device_found = self.device_found and d.exists(descriptionContains='Name')
+        self.device_found = self.device_found and d.exists(descriptionContains='Data models')
+        self.device_found = self.device_found and d.exists(descriptionContains='Core spec version')
+        self.device_found = self.device_found and d.exists(descriptionContains='Role')
+
+        self.assertTrue(self.device_found, 'OCF device is not found.')
+
+
+    @classmethod
+    def tearDownClass(cls):
+        '''Terminate the app.'''
+        cls.appmgr.kill_app(cls.pkg_id)
+

--- a/meta-iotqa/lib/oeqa/runtime/nodejs/ocfdemoapp/gas.py
+++ b/meta-iotqa/lib/oeqa/runtime/nodejs/ocfdemoapp/gas.py
@@ -1,0 +1,94 @@
+#!/usr/bin/env python3
+
+import os
+import sys
+import time
+import subprocess
+
+from uiautomator import device as d
+
+from oeqa.oetest import oeRuntimeTest
+
+sys.path.append(os.path.dirname(__file__))
+from appmgr import AppMgr
+import data_settings
+
+
+class CordovaPluginOCFDemoAppGasTest(oeRuntimeTest):
+    '''Automatize the Cordova plugin OCF demo app tests like
+    checking if the resources are found, and resource information is readonly.
+    '''
+    pkg_id = 'com.example.CordovaPluginOcfDemo'
+    gas_item = None
+    device_found = False
+    resource_found = False
+
+    details_btn = None
+    id_item = None
+    gas_value_item = None
+    gas_value = None
+
+    appmgr = AppMgr()
+
+    @classmethod
+    def setUpClass(cls):
+        '''
+        Launch the app and find the OCF resources.
+        '''
+        cls.appmgr.kill_app(cls.pkg_id)
+        cls.appmgr.launch_app(cls.pkg_id)
+        time.sleep(data_settings.app_launch_and_wait)
+
+
+    def init_gas_sensor(self):
+        '''
+        Go to the detailed page of the OCF resource.
+        '''
+        self.gas_item = d(className='android.view.View', descriptionContains='Path: /a/gas')
+        self.gas_item.click()
+        time.sleep(1)
+
+        self.details_btn = d(className='android.widget.Button')
+        self.id_item = d(className='android.view.View', descriptionStartsWith='id')
+        self.gas_value_item = d(className='android.view.View', descriptionStartsWith='value')
+        self.gas_value = self.gas_value_item.description.split(':')[-1].strip()
+
+
+    def test_gas_resource_found(self):
+        '''Check if the gas resources can be found.'''
+        self.appmgr.go_to_resources_for_ocfdemo()
+        time.sleep(data_settings.app_found_res_and_wait)
+
+        self.resource_found = d.exists(className='android.view.View', descriptionContains='/a/gas')
+        self.assertTrue(self.resource_found, 'The gas resource is not found.')
+
+
+    def test_gas_resource_properties_readonly(self):
+        '''Check if the properties of gas resource are readonly.'''
+        self.init_gas_sensor()
+
+        self.assertEqual(len(self.details_btn), 1, 'The properties of gas are not readonly.')
+        self.assertEqual(self.id_item.description.split(':')[-1].strip(), 'gasSensor',
+                        'Id of gas resource not found.')
+        self.assertEqual(self.gas_value, 'false', 'Initial gas value is not false!')
+
+
+    def test_gas_z_device_found(self):
+        ''''Check if the OCF device can be found.'''
+        self.appmgr.go_to_devices_for_ocfdemo()
+        time.sleep(data_settings.app_found_dev_and_wait)
+
+        self.device_found = d.exists(descriptionContains='UUID')
+        self.device_found = self.device_found and d.exists(descriptionContains='URL')
+        self.device_found = self.device_found and d.exists(descriptionContains='Name')
+        self.device_found = self.device_found and d.exists(descriptionContains='Data models')
+        self.device_found = self.device_found and d.exists(descriptionContains='Core spec version')
+        self.device_found = self.device_found and d.exists(descriptionContains='Role')
+
+        self.assertTrue(self.device_found, 'OCF device is not found.')
+
+    @classmethod
+    def tearDownClass(cls):
+        '''Terminate the app.'''
+        cls.appmgr.kill_app(cls.pkg_id)
+

--- a/meta-iotqa/lib/oeqa/runtime/nodejs/ocfdemoapp/led.py
+++ b/meta-iotqa/lib/oeqa/runtime/nodejs/ocfdemoapp/led.py
@@ -1,0 +1,95 @@
+#!/usr/bin/env python3
+
+import os
+import sys
+import time
+import subprocess
+
+from uiautomator import device as d
+
+from oeqa.oetest import oeRuntimeTest
+
+sys.path.append(os.path.dirname(__file__))
+from appmgr import AppMgr
+import data_settings
+
+
+class CordovaPluginOCFDemoAppLedTest(oeRuntimeTest):
+    '''Automatize the Cordova plugin OCF demo app tests like
+    checking if the resources are found, and resource information is readonly.
+    '''
+    pkg_id = 'com.example.CordovaPluginOcfDemo'
+    led_item = None
+    device_found = False
+    resource_found = False
+
+    details_btn = None
+    id_item = None
+    led_value_item = None
+    led_value = None
+
+    appmgr = AppMgr()
+
+    @classmethod
+    def setUpClass(cls):
+        '''
+        Launch the app and find the OCF resources.
+        '''
+        cls.appmgr.kill_app(cls.pkg_id)
+        cls.appmgr.launch_app(cls.pkg_id)
+        time.sleep(data_settings.app_launch_and_wait)
+
+
+    def init_led_sensor(self):
+        '''
+        Go to the detailed page of the OCF resource.
+        '''
+        self.led_item = d(className='android.view.View', descriptionContains='Path: /a/led')
+        self.led_item.click()
+        time.sleep(1)
+
+        self.details_btn = d(className='android.widget.Button')
+        self.id_item = d(className='android.view.View', descriptionStartsWith='id')
+        self.led_value_item = d(className='android.view.View', index=14).child(className='android.view.View', index=1)
+        self.led_value = self.led_value_item.description
+
+
+    def test_led_resource_found(self):
+        '''Check if the led resources can be found.'''
+        self.appmgr.go_to_resources_for_ocfdemo()
+        time.sleep(data_settings.app_found_res_and_wait)
+
+        self.resource_found = d.exists(className='android.view.View', descriptionContains='/a/led')
+        self.assertTrue(self.resource_found, 'The led resource is not found.')
+
+
+    def test_led_resource_has_properties(self):
+        '''Check if the led resource has properties like id and value.'''
+        self.init_led_sensor()
+
+        self.assertEqual(len(self.details_btn), 2)
+        self.assertEqual(self.id_item.description.split(':')[-1].strip(), 'led', 
+                        'Id of led resource not found.')
+        self.assertEqual(self.led_value, 'false', 'Initial led value is not false!')
+
+
+    def test_led_z_device_found(self):
+        ''''Check if the OCF device can be found.'''
+        self.appmgr.go_to_devices_for_ocfdemo()
+        time.sleep(data_settings.app_found_dev_and_wait)
+
+        self.device_found = d.exists(descriptionContains='UUID')
+        self.device_found = self.device_found and d.exists(descriptionContains='URL')
+        self.device_found = self.device_found and d.exists(descriptionContains='Name')
+        self.device_found = self.device_found and d.exists(descriptionContains='Data models')
+        self.device_found = self.device_found and d.exists(descriptionContains='Core spec version')
+        self.device_found = self.device_found and d.exists(descriptionContains='Role')
+
+        self.assertTrue(self.device_found, 'OCF device is not found.')
+
+
+    @classmethod
+    def tearDownClass(cls):
+        '''Terminate the app.'''
+        cls.appmgr.kill_app(cls.pkg_id)
+

--- a/meta-iotqa/lib/oeqa/runtime/nodejs/ocfdemoapp/motion.py
+++ b/meta-iotqa/lib/oeqa/runtime/nodejs/ocfdemoapp/motion.py
@@ -1,0 +1,95 @@
+#!/usr/bin/env python3
+
+import os
+import sys
+import time
+import subprocess
+
+from uiautomator import device as d
+
+from oeqa.oetest import oeRuntimeTest
+
+sys.path.append(os.path.dirname(__file__))
+from appmgr import AppMgr
+import data_settings
+
+
+class CordovaPluginOCFDemoAppMotionTest(oeRuntimeTest):
+    '''Automatize the Cordova plugin OCF demo app tests like
+    checking if the resources are found, and resource information is readonly.
+    '''
+    pkg_id = 'com.example.CordovaPluginOcfDemo'
+    motion_item = None
+    device_found = False
+    resource_found = False
+
+    details_btn = None
+    id_item = None
+    motion_value_item = None
+    motion_value = None
+
+    appmgr = AppMgr()
+
+    @classmethod
+    def setUpClass(cls):
+        '''
+        Launch the app and find the OCF resources.
+        '''
+        cls.appmgr.kill_app(cls.pkg_id)
+        cls.appmgr.launch_app(cls.pkg_id)
+        time.sleep(data_settings.app_launch_and_wait)
+
+
+    def init_motion_sensor(self):
+        '''
+        Go to the detailed page of the OCF resource.
+        '''
+        self.motion_item = d(className='android.view.View', descriptionContains='Path: /a/pir')
+        self.motion_item.click()
+        time.sleep(1)
+
+        self.details_btn = d(className='android.widget.Button')
+        self.id_item = d(className='android.view.View', descriptionStartsWith='id')
+        self.motion_value_item = d(className='android.view.View', descriptionStartsWith='value')
+        self.motion_value = self.motion_value_item.description.split(':')[-1].strip()
+
+
+    def test_motion_resource_found(self):
+        '''Check if the motion resources can be found.'''
+        self.appmgr.go_to_resources_for_ocfdemo()
+        time.sleep(data_settings.app_found_res_and_wait)
+
+        self.resource_found = d.exists(className='android.view.View', descriptionContains='/a/pir')
+        self.assertTrue(self.resource_found, 'The motion resource is not found.')
+
+
+    def test_motion_resource_properties_readonly(self):
+        '''Check if the properties of the motion resource are readonly'''
+        self.init_motion_sensor()
+
+        self.assertEqual(len(self.details_btn), 1, 'The properties of gas are not readonly.')
+        self.assertEqual(self.id_item.description.split(':')[-1].strip(), 'motionSensor',
+                        'Id of motion resource not found.')
+        self.assertEqual(self.motion_value, 'false', 'Initial motion value is not false!')
+
+
+    def test_motion_z_device_found(self):
+        ''''Check if the OCF device can be found.'''
+        self.appmgr.go_to_devices_for_ocfdemo()
+        time.sleep(data_settings.app_found_dev_and_wait)
+
+        self.device_found = d.exists(descriptionContains='UUID')
+        self.device_found = self.device_found and d.exists(descriptionContains='URL')
+        self.device_found = self.device_found and d.exists(descriptionContains='Name')
+        self.device_found = self.device_found and d.exists(descriptionContains='Data models')
+        self.device_found = self.device_found and d.exists(descriptionContains='Core spec version')
+        self.device_found = self.device_found and d.exists(descriptionContains='Role')
+
+        self.assertTrue(self.device_found, 'OCF device is not found.')
+
+
+    @classmethod
+    def tearDownClass(cls):
+        '''Terminate the app.'''
+        cls.appmgr.kill_app(cls.pkg_id)
+

--- a/meta-iotqa/lib/oeqa/runtime/nodejs/ocfdemoapp/power.py
+++ b/meta-iotqa/lib/oeqa/runtime/nodejs/ocfdemoapp/power.py
@@ -1,0 +1,102 @@
+#!/usr/bin/power python3
+
+import os
+import sys
+import time
+import subprocess
+
+from uiautomator import device as d
+
+from oeqa.oetest import oeRuntimeTest
+
+sys.path.append(os.path.dirname(__file__))
+from appmgr import AppMgr
+import data_settings
+
+
+class CordovaPluginOCFDemoAppPowerTest(oeRuntimeTest):
+    '''Automatize the Cordova plugin OCF demo app tests like
+    checking if the resources are found, and resource information is readonly.
+    '''
+    pkg_id = 'com.example.CordovaPluginOcfDemo'
+    power_item = None
+    device_found = False
+    resource_found = False
+
+    details_btn = None
+    power1_item = None
+    power1_value = 0.0
+    id_item = None
+    power2_item = None
+    power2_value = 0.0
+
+    appmgr = AppMgr()
+
+    @classmethod
+    def setUpClass(cls):
+        '''
+        Launch the app and find the OCF resources.
+        '''
+        cls.appmgr.kill_app(cls.pkg_id)
+        cls.appmgr.launch_app(cls.pkg_id)
+        time.sleep(data_settings.app_launch_and_wait)
+
+
+    def init_power_sensor(self):
+        '''
+        Go to the detaipower page of the OCF resource.
+        '''
+        self.power_item = d(className='android.view.View', descriptionContains='Path: /a/power')
+        self.power_item.click()
+        time.sleep(1)
+
+        self.details_btn = d(className='android.widget.Button')
+        self.power1_item = d(className='android.view.View', descriptionStartsWith='power1')
+        self.power1_value = float(self.power1_item.description.split(':')[-1].strip())
+
+        self.id_item = d(className='android.view.View', descriptionStartsWith='id')
+
+        self.power2_item = d(className='android.view.View', descriptionStartsWith='power2')
+        self.power2_value = float(self.power2_item.description.split(':')[-1].strip())
+
+
+    def test_power_resource_found(self):
+        '''Check if the power resources can be found.'''
+        self.appmgr.go_to_resources_for_ocfdemo()
+        time.sleep(data_settings.app_found_res_and_wait)
+
+        self.resource_found = d.exists(className='android.view.View', descriptionContains='/a/power')
+        self.assertTrue(self.resource_found, 'The power resource is not found.')
+
+
+    def test_power_resource_has_properties(self):
+        '''Check if the power resource has properties like id and value.'''
+        self.init_power_sensor()
+
+        self.assertEqual(len(self.details_btn), 1)
+        self.assertEqual(self.id_item.description.split(':')[-1].strip(), 'power',
+                         'Id of power resource not found.', )
+        self.assertTrue(self.power1_value >= 0.0, 'power1 value seems not sensible')
+        self.assertTrue(self.power2_value >= 0.0, 'power2 value seems not sensible')
+
+
+    def test_power_z_device_found(self):
+        ''''Check if the OCF device can be found.'''
+        self.appmgr.go_to_devices_for_ocfdemo()
+        time.sleep(data_settings.app_found_dev_and_wait)
+
+        self.device_found = d.exists(descriptionContains='UUID')
+        self.device_found = self.device_found and d.exists(descriptionContains='URL')
+        self.device_found = self.device_found and d.exists(descriptionContains='Name')
+        self.device_found = self.device_found and d.exists(descriptionContains='Data models')
+        self.device_found = self.device_found and d.exists(descriptionContains='Core spec version')
+        self.device_found = self.device_found and d.exists(descriptionContains='Role')
+
+        self.assertTrue(self.device_found, 'OCF device is not found.')
+
+
+    @classmethod
+    def tearDownClass(cls):
+        '''Terminate the app.'''
+        cls.appmgr.kill_app(cls.pkg_id)
+

--- a/meta-iotqa/lib/oeqa/runtime/nodejs/ocfdemoapp/rgb_led.py
+++ b/meta-iotqa/lib/oeqa/runtime/nodejs/ocfdemoapp/rgb_led.py
@@ -1,0 +1,99 @@
+#!/usr/bin/env python3
+
+import os
+import sys
+import time
+import subprocess
+
+from uiautomator import device as d
+
+from oeqa.oetest import oeRuntimeTest
+
+sys.path.append(os.path.dirname(__file__))
+from appmgr import AppMgr
+import data_settings
+
+
+class CordovaPluginOCFDemoAppRGBLedTest(oeRuntimeTest):
+    '''Automatize the Cordova plugin OCF demo app tests like
+    checking if the resources are found, and resource information is readonly.
+    '''
+    pkg_id = 'com.example.CordovaPluginOcfDemo'
+    rgb_led_item = None
+    device_found = False
+    resource_found = False
+
+    details_btn = None
+    id_item = None
+    range_item = None
+    rgb_led_value_item = None
+    rgb_led_value = None
+
+    appmgr = AppMgr()
+
+    @classmethod
+    def setUpClass(cls):
+        '''
+        Launch the app and find the OCF resources.
+        '''
+        cls.appmgr.kill_app(cls.pkg_id)
+        cls.appmgr.launch_app(cls.pkg_id)
+        time.sleep(data_settings.app_launch_and_wait)
+
+
+    def init_rgb_led_sensor(self):
+        '''
+        Go to the detairgb_led page of the OCF resource.
+        '''
+        self.rgb_led_item = d(className='android.view.View', descriptionContains='Path: /a/rgbled')
+        self.rgb_led_item.click()
+        time.sleep(1)
+
+        self.details_btn = d(className='android.widget.Button')
+        self.id_item = d(className='android.view.View', descriptionStartsWith='id')
+        self.range_item = d(className='android.view.View', descriptionStartsWith='range')
+        self.rgb_led_value_item = d(className='android.view.View', index=15).child(className='android.view.View', index=1)
+        self.rgb_led_value = self.rgb_led_value_item.description
+
+
+    def test_rgb_led_resource_found(self):
+        '''Check if the rgb_led resources can be found.'''
+        self.appmgr.go_to_resources_for_ocfdemo()
+        time.sleep(data_settings.app_found_res_and_wait)
+
+        self.resource_found = d.exists(className='android.view.View', descriptionContains='/a/rgbled')
+        self.assertTrue(self.resource_found, 'The motion resource is not found.')
+
+
+    def test_rgb_led_resource_has_properties(self):
+        '''Check if the rgb_led resource has properties like id and value.'''
+        self.init_rgb_led_sensor()
+
+        self.assertEqual(len(self.details_btn), 2)
+        self.assertEqual(self.id_item.description.split(':')[-1].strip(), 'rgbled', 
+                        'Id of rgb_led resource not found.', )
+        self.assertEqual(self.range_item.description.split(':')[-1].strip(), '[0, 255]', 
+                        'RGB led range is empty!')
+        self.assertTrue(self.rgb_led_value.strip() <= '255, 255, 255', 'rgb_led value is invalid!')
+
+
+    def test_rgb_led_z_device_found(self):
+        ''''Check if the OCF device can be found.'''
+        self.appmgr.go_to_devices_for_ocfdemo()
+        time.sleep(data_settings.app_found_dev_and_wait)
+
+        self.device_found = d.exists(descriptionContains='UUID')
+        self.device_found = self.device_found and d.exists(descriptionContains='URL')
+        self.device_found = self.device_found and d.exists(descriptionContains='Name')
+        self.device_found = self.device_found and d.exists(descriptionContains='Data models')
+        self.device_found = self.device_found and d.exists(descriptionContains='Core spec version')
+        self.device_found = self.device_found and d.exists(descriptionContains='Role')
+
+        self.assertTrue(self.device_found, 'OCF device is not found.')
+
+
+    @classmethod
+    def tearDownClass(cls):
+        '''Terminate the app.'''
+        cls.appmgr.kill_app(cls.pkg_id)
+

--- a/meta-iotqa/lib/oeqa/runtime/nodejs/ocfdemoapp/solar.py
+++ b/meta-iotqa/lib/oeqa/runtime/nodejs/ocfdemoapp/solar.py
@@ -1,0 +1,104 @@
+#!/usr/bin/env python3
+
+import os
+import sys
+import time
+import subprocess
+
+from uiautomator import device as d
+
+from oeqa.oetest import oeRuntimeTest
+
+sys.path.append(os.path.dirname(__file__))
+from appmgr import AppMgr
+import data_settings
+
+class CordovaPluginOCFDemoAppSolarTest(oeRuntimeTest):
+    '''Automatize the Cordova plugin OCF demo app tests like
+    checking if the resources are found, and resource information is readonly.
+    '''
+    pkg_id = 'com.example.CordovaPluginOcfDemo'
+    solar_item = None
+    device_found = False
+    resource_found = False
+
+    details_btn = None
+    id_item = None
+    lcd1_item = None
+    lcd2_item = None
+    simu_item = None
+    solar_value_item = None
+    solar_value = None
+
+    appmgr = AppMgr()
+
+    @classmethod
+    def setUpClass(cls):
+        '''
+        Launch the app and find the OCF resources.
+        '''
+        cls.appmgr.kill_app(cls.pkg_id)
+        cls.appmgr.launch_app(cls.pkg_id)
+        time.sleep(data_settings.app_launch_and_wait)
+
+
+    def init_solar_sensor(self):
+        '''
+        Go to the detaisolar page of the OCF resource.
+        '''
+        self.solar_item = d(className='android.view.View', descriptionContains='Path: /a/solar')
+        self.solar_item.click()
+        time.sleep(1)
+
+        self.details_btn = d(className='android.widget.Button')
+        self.id_item = d(className='android.view.View', descriptionStartsWith='id')
+        self.lcd1_item = d(className='android.view.View', descriptionStartsWith='lcd1')
+        self.lcd2_item = d(className='android.view.View', descriptionStartsWith='lcd2')
+        self.simu_item = d(className='android.view.View', descriptionStartsWith='simulationMode')
+        self.solar_value_item = d(className='android.view.View', index=17).child(className='android.view.View', index=1)
+        self.solar_value = self.solar_value_item.description
+
+
+    def test_solar_resource_found(self):
+        '''Check if the solar resources can be found.'''
+        self.appmgr.go_to_resources_for_ocfdemo()
+        time.sleep(data_settings.app_found_res_and_wait)
+
+        self.resource_found = d.exists(className='android.view.View', descriptionContains='/a/solar')
+        self.assertTrue(self.resource_found, 'The solar resource is not found.')
+
+
+    def test_solar_resource_has_properties(self):
+        '''Check if the solar resource has properties like id and value.'''
+        self.init_solar_sensor()
+
+        self.assertEqual(len(self.details_btn), 3)
+        self.assertEqual(self.id_item.description.split(':')[-1].strip(), 'solar', 
+                         'Id of solar resource not found.', )
+        self.assertEqual(self.lcd1_item.description.split(':')[-1].strip(), 'Solar Connected!!',
+                         'LCD1 text is empty!')
+        self.assertEqual(self.lcd2_item.description.split(':')[-1].strip(), '',
+                         'LCD2 text is not empty!')
+        self.assertEqual(self.solar_value, '0', 'solar value is empty!')
+
+
+    def test_solar_z_device_found(self):
+        ''''Check if the OCF device can be found.'''
+        self.appmgr.go_to_devices_for_ocfdemo()
+        time.sleep(data_settings.app_found_dev_and_wait)
+
+        self.device_found = d.exists(descriptionContains='UUID')
+        self.device_found = self.device_found and d.exists(descriptionContains='URL')
+        self.device_found = self.device_found and d.exists(descriptionContains='Name')
+        self.device_found = self.device_found and d.exists(descriptionContains='Data models')
+        self.device_found = self.device_found and d.exists(descriptionContains='Core spec version')
+        self.device_found = self.device_found and d.exists(descriptionContains='Role')
+
+        self.assertTrue(self.device_found, 'OCF device is not found.')
+
+
+    @classmethod
+    def tearDownClass(cls):
+        '''Terminate the app.'''
+        cls.appmgr.kill_app(cls.pkg_id)
+

--- a/meta-iotqa/lib/oeqa/runtime/nodejs/ocfdemoapp/switch.py
+++ b/meta-iotqa/lib/oeqa/runtime/nodejs/ocfdemoapp/switch.py
@@ -1,0 +1,95 @@
+#!/usr/bin/env python3
+
+import os
+import sys
+import time
+import subprocess
+
+from uiautomator import device as d
+
+from oeqa.oetest import oeRuntimeTest
+
+sys.path.append(os.path.dirname(__file__))
+from appmgr import AppMgr
+import data_settings
+
+
+class CordovaPluginOCFDemoAppSwitchTest(oeRuntimeTest):
+    '''Automatize the Cordova plugin OCF demo app tests like
+    checking if the resources are found, and resource information is readonly.
+    '''
+    pkg_id = 'com.example.CordovaPluginOcfDemo'
+    switch_item = None
+    device_found = False
+    resource_found = False
+
+    details_btn = None
+    id_item = None
+    switch_value_item = None
+    switch_value = None
+
+    appmgr = AppMgr()
+
+    @classmethod
+    def setUpClass(cls):
+        '''
+        Launch the app and find the OCF resources.
+        '''
+        cls.appmgr.kill_app(cls.pkg_id)
+        cls.appmgr.launch_app(cls.pkg_id)
+        time.sleep(data_settings.app_launch_and_wait)
+
+
+    def init_switch_sensor(self):
+        '''
+        Go to the detaiswitch page of the OCF resource.
+        '''
+        self.switch_item = d(className='android.view.View', descriptionContains='Path: /a/binarySwitch')
+        self.switch_item.click()
+        time.sleep(data_settings.app_found_res_and_wait)
+
+        self.details_btn = d(className='android.widget.Button')
+        self.id_item = d(className='android.view.View', descriptionStartsWith='id')
+        self.switch_value_item = d(className='android.view.View', descriptionStartsWith='value')
+        self.switch_value = self.switch_value_item.description.split(':')[-1].strip()
+
+
+    def test_switch_resource_found(self):
+        '''Check if the switch resources can be found.'''
+        self.appmgr.go_to_resources_for_ocfdemo()
+        time.sleep(10)
+
+        self.resource_found = d.exists(className='android.view.View', descriptionContains='/a/binarySwitch')
+        self.assertTrue(self.resource_found, 'The switch resource is not found.')
+
+
+    def test_switch_resource_properties_readonly(self):
+        '''Check if the switch resource has properties like id and value.'''
+        self.init_switch_sensor()
+
+        self.assertEqual(len(self.details_btn), 1, 'The properties of switch are not readonly.')
+        self.assertEqual(self.id_item.description.split(':')[-1].strip(), 'binarySwitch',
+                        'Id of switch resource not found.')
+        self.assertEqual(self.switch_value, 'false', 'Initial switch value is not false!')
+
+
+    def test_switch_z_device_found(self):
+        ''''Check if the OCF device can be found.'''
+        self.appmgr.go_to_devices_for_ocfdemo()
+        time.sleep(data_settings.app_found_dev_and_wait)
+
+        self.device_found = d.exists(descriptionContains='UUID')
+        self.device_found = self.device_found and d.exists(descriptionContains='URL')
+        self.device_found = self.device_found and d.exists(descriptionContains='Name')
+        self.device_found = self.device_found and d.exists(descriptionContains='Data models')
+        self.device_found = self.device_found and d.exists(descriptionContains='Core spec version')
+        self.device_found = self.device_found and d.exists(descriptionContains='Role')
+
+        self.assertTrue(self.device_found, 'OCF device is not found.')
+
+
+    @classmethod
+    def tearDownClass(cls):
+        '''Terminate the app.'''
+        cls.appmgr.kill_app(cls.pkg_id)
+

--- a/meta-iotqa/lib/oeqa/runtime/nodejs/ocfdemoapp/temperature.py
+++ b/meta-iotqa/lib/oeqa/runtime/nodejs/ocfdemoapp/temperature.py
@@ -1,0 +1,105 @@
+#!/usr/bin/env python3
+
+import os
+import sys
+import time
+import subprocess
+
+from uiautomator import device as d
+from uiautomator import JsonRPCError
+
+from oeqa.oetest import oeRuntimeTest
+
+sys.path.append(os.path.dirname(__file__))
+from appmgr import AppMgr
+import data_settings
+
+
+class CordovaPluginOCFDemoAppTemperatureTest(oeRuntimeTest):
+    '''Automatize the Cordova plugin OCF demo app tests like
+    checking if the resources are found, and resource information is readonly.'''
+
+    pkg_id = 'com.example.CordovaPluginOcfDemo'
+    temperature_item = None
+    device_found = False
+    resource_found = False
+
+    details_btn = None
+    id_item = None
+    range_item = None
+    temperature_value_item = None
+    temperature_value = 0.0
+    units_item = None
+
+    appmgr = AppMgr()
+
+    @classmethod
+    def setUpClass(cls):
+        '''
+        Launch the app and find the OCF resources.
+        '''
+        cls.appmgr.kill_app(cls.pkg_id)
+        cls.appmgr.launch_app(cls.pkg_id)
+        time.sleep(data_settings.app_launch_and_wait)
+
+
+    def init_temperature_sensor(self):
+        '''
+        Go to the detailed page of the OCF resource.
+        '''
+        self.temperature_item = d(className='android.view.View', descriptionContains='Path: /a/temperature')
+        self.temperature_item.click()
+        time.sleep(1)
+
+        self.details_btn = d(className='android.widget.Button')
+        self.id_item = d(className='android.view.View', descriptionStartsWith='id')
+        self.range_item = d(className='android.view.View', descriptionStartsWith='range')
+        self.temperature_value_item = d(className='android.view.View', descriptionStartsWith='temperature')
+        self.temperature_value = float(self.temperature_value_item.description.split(':')[-1].strip())
+
+        self.units_item = d(className='android.view.View', descriptionStartsWith='units')
+
+
+    def test_temeperature_resource_found(self):
+        '''Check if the temperature resources can be found.'''
+        self.appmgr.go_to_resources_for_ocfdemo()
+        time.sleep(data_settings.app_found_res_and_wait)
+
+        self.resource_found = d.exists(className='android.view.View', descriptionContains='/a/temperature')
+        self.assertTrue(self.resource_found, 'The temperature resource is not found.')
+
+
+    def test_temeperature_resource_properties_readonly(self):
+        '''Check if the properties of temperature resources are readonly.'''
+        self.init_temperature_sensor()
+
+        self.assertEqual(len(self.details_btn), 1, 'The properties of temperature are not readonly.')
+        self.assertEqual(self.id_item.description.split(':')[-1].strip(), 'temperature', 
+                        'Device of temperature resource not found.')
+        self.assertEqual(self.range_item.description.split(':')[-1].strip(), '-40,125',
+                        'Temperature range is invalid.')
+        self.assertTrue(self.temperature_value > 10.0, 'Temperature value seems not sensible in Zhizu1 Lab.')
+        self.assertTrue(self.units_item.description.split(':')[-1].strip() in ('C', 'F', 'K'),
+                        'Temperature units is invalid.')
+
+
+    def test_temeperature_z_device_found(self):
+        ''''Check if the OCF device can be found.'''
+        self.appmgr.go_to_devices_for_ocfdemo()
+        time.sleep(data_settings.app_found_dev_and_wait)
+
+        self.device_found = d.exists(descriptionContains='UUID')
+        self.device_found = self.device_found and d.exists(descriptionContains='URL')
+        self.device_found = self.device_found and d.exists(descriptionContains='Name')
+        self.device_found = self.device_found and d.exists(descriptionContains='Data models')
+        self.device_found = self.device_found and d.exists(descriptionContains='Core spec version')
+        self.device_found = self.device_found and d.exists(descriptionContains='Role')
+
+        self.assertTrue(self.device_found, 'OCF device is not found.')
+
+
+    @classmethod
+    def tearDownClass(cls):
+        '''Terminate the app.'''
+        cls.appmgr.kill_app(cls.pkg_id)
+

--- a/meta-iotqa/lib/oeqa/runtime/nodejs/restapiserver/rest_no_ocf_server_local.py
+++ b/meta-iotqa/lib/oeqa/runtime/nodejs/restapiserver/rest_no_ocf_server_local.py
@@ -1,0 +1,76 @@
+#!/usr/bin/env python3
+
+import os
+import sys
+import time
+import json
+
+from oeqa.oetest import oeRuntimeTest
+
+sys.path.append(os.path.dirname(__file__))
+import copy_necessary_files
+import restapi_case_config
+
+
+class OCFDiscoveryTest(oeRuntimeTest):
+    
+    case_config = restapi_case_config.RestApiCaseConfiguration()
+
+    @classmethod
+    def setUpClass(cls):
+        '''
+        Copy necessary files to target.
+        '''
+        if cls.case_config.need_copy_files:
+            copy_necessary_files.copy_smarthome_demo_ocf_server(cls.tc.target.ip)
+            copy_necessary_files.copy_rest_api_ocf_discovery_js(cls.tc.target.ip)
+
+        # cls.case_config.prepare_test(cls.tc.target)
+
+    def test_ocf_discovery(self):
+        '''
+        Send REST request again and find only one OCF device.
+        '''
+        test_cmd = 'export NODE_PATH=/usr/lib/node_modules/;'\
+                   'cd {js_test_dir};./node_modules/mocha/bin/mocha -R json'.format(
+                        js_test_dir = self.case_config.ocf_js_test_dir)
+        (status, output) = self.target.run(test_cmd)
+
+        self.parse_test_results(output)
+
+
+    def parse_test_results(self, output):
+        '''
+        Parse the test results from mocha JSON format.
+        '''
+        results = json.loads(output.strip())
+
+        template = '%s - runtest.py - RESULTS - Testcase %s: %s\n'
+        results_data = []
+        for failure in results.get('failures'):
+            result = template % (time.strftime('%H:%M:%S', time.gmtime()),
+                        failure.get('title'), 'FAILED')
+            results_data.append(result)
+        for block in results.get('pending'):
+            result = template % (time.strftime('%H:%M:%S', time.gmtime()),
+                        block.get('title'), 'BLOCKED')
+            results_data.append(result)
+        for passe in results.get('passes'):
+            result = template % (time.strftime('%H:%M:%S', time.gmtime()),
+                        passe.get('title'), 'PASS')
+            results_data.append(result)
+
+        root_dir = None
+        nodejs_dir = os.path.dirname(__file__)        
+        root_dir = os.path.dirname(os.path.dirname(os.path.dirname(os.path.dirname(nodejs_dir))))
+        result_log = os.path.join(root_dir, 'ocf_discovery.log')
+        with open(result_log, 'w') as f:
+            f.writelines(results_data)
+
+
+    @classmethod
+    def tearDownClass(cls):
+        '''
+        Clean up work.
+        '''
+        cls.case_config.clean_up(cls.tc.target)

--- a/meta-iotqa/lib/oeqa/runtime/nodejs/smarthomectlapp/app.py
+++ b/meta-iotqa/lib/oeqa/runtime/nodejs/smarthomectlapp/app.py
@@ -1,0 +1,113 @@
+#!/usr/bin/env python3
+
+import os
+import sys
+import time
+import subprocess
+
+from uiautomator import device as d
+sys.path.append(os.path.join(os.path.dirname(os.path.dirname(__file__)), 'ocfdemoapp'))
+from appmgr import AppMgr
+
+from oeqa.oetest import oeRuntimeTest
+
+
+class SHCtrlAppBuildAndLaunchTest(oeRuntimeTest):
+    '''
+    Build/Install/Launch the Smart Home Control app.
+    '''
+
+    workspace_dir = os.path.dirname(__file__)
+    smart_home_control_url = 'https://github.com/siovene/smart-home-control.git'
+    pkg_id = 'com.intel.otc.cordova.SmartHomeControl'
+    repo_dir = 'smart-home-control'
+    prj_dir = os.path.join(workspace_dir, repo_dir)
+    apk_path = 'platforms/android/build/outputs/apk/android-debug.apk'
+
+    clean_up = False
+    uninstall_app = False
+    appmgr = AppMgr()
+
+    def setUp(self):
+        '''
+        Check if the grunt-cli and bower are installed. Install them globally if not.
+        '''
+        self.appmgr.uninstall_app(self.pkg_id)
+
+        cli_cmd = ['grunt', 'bower']
+        for cmd in cli_cmd:
+            detect_cmd = ['which'] + [cmd]
+            proc = subprocess.Popen(detect_cmd, stdout = subprocess.PIPE, stderr=subprocess.STDOUT)
+            proc.wait()
+
+            if proc.returncode != 0:
+                if cmd == 'grunt':
+                    cli = 'grunt-cli'
+                else:
+                    cli = cmd
+                print('{} not installed, install it...'.format(cli))
+                proc_cli = subprocess.Popen(['sudo', '-E', 'npm', cli, '-g'])
+                proc_cli.communicate()
+
+            else:
+                print('{} has been installed'.format(cmd))
+
+        detect_dev = ['adb', 'devices']
+        proc_adb = subprocess.Popen(detect_dev, stdout = subprocess.PIPE, stderr=subprocess.STDOUT)
+        proc_adb.wait()
+
+        adb_info = proc_adb.stdout.read().decode('utf8').strip()
+        if proc_adb.returncode != 0 or not adb_info.endswith('device'):
+            print('Please check if the android device is connected to the host.')
+
+
+    def test_shctrl_build_install_launch(self):
+        '''
+        Check if there're any errors during the following steps:
+        1. git clone the cordova-plugin-ocf-demo
+        2. build the app
+        3. install and launch it
+        '''
+        clone_cmd = ['git', 'clone', '--depth', '1', '--single-branch', '--branch', 'master', 
+                    self.smart_home_control_url]
+        clone_proc = subprocess.Popen(clone_cmd, cwd = self.workspace_dir)
+        clone_proc.wait()
+
+        self.assertEqual(clone_proc.returncode, 0, 'clone the smart-home-control failed.')
+
+        build_cmds = [['npm', 'install'], ['bower', 'install'], 
+                    ['grunt', 'platform:add:android'], ['grunt', 'build']]
+        for build_cmd in build_cmds:
+            build_proc = subprocess.Popen(build_cmd, cwd = self.prj_dir)
+            build_proc.wait()
+
+            self.assertEqual(build_proc.returncode, 0, 'Failed to build when running [{}]'.format(build_cmd))
+
+        self.assertTrue(os.path.exists(self.prj_dir), 'smart-home-control apk is not found!')
+        install_cmd = ['adb', 'install',  self.apk_path]
+        install_proc = subprocess.Popen(install_cmd, cwd = self.prj_dir)
+        install_proc.wait()
+
+        self.assertEqual(install_proc.returncode, 0, 'Failed to install smart-home-control apk')
+
+        self.appmgr.launch_app(self.pkg_id)
+        time.sleep(5)
+
+        btn = d(className='android.widget.Button', index=0)
+        btn.click()
+
+        title_found = d(className='android.view.View', descriptionContains='Smart Home Control').exists
+        self.assertTrue(title_found, 'Launching the app OK?')
+
+
+    def tearDown(self):
+        '''
+        Remove the cordova-plugin-ocf-demo project as it not needed any more.
+        '''
+        if self.clean_up:
+            os.chdir(self.workspace_dir)
+            os.system('rm -fr {}'.format(self.repo_dir))
+
+        if self.uninstall_app:
+            self.appmgr.uninstall_app(self.pkg_id)
+        


### PR DESCRIPTION
Add automatic cases for cordova-plugin-ocf-demo and smart-home-control app
* Cordova-plugin-ocf-demo cases: 42
* Build and install cases: 2

Test results: new: 44 pass: 44 failed: 0

Signed-off-by: Qiu Zhong <zhongx.qiu@intel.com>